### PR TITLE
chore(workflows): add `expo install --fix` workflow

### DIFF
--- a/.github/workflows/expo-install-fix.yml
+++ b/.github/workflows/expo-install-fix.yml
@@ -1,4 +1,4 @@
-name: Expo Dependencies
+name: expo install --fix
 
 on:
   workflow_dispatch:

--- a/.github/workflows/expo-install-fix.yml
+++ b/.github/workflows/expo-install-fix.yml
@@ -3,7 +3,7 @@ name: Expo Dependencies
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '30 1,13 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/expo-install-fix.yml
+++ b/.github/workflows/expo-install-fix.yml
@@ -1,0 +1,46 @@
+name: Expo Dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - run: corepack enable yarn
+
+      - uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+
+      - run: yarn expo install --fix
+        working-directory: ./app
+
+      - id: app_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ vars.KEYCHAIN_BOT_APP_ID }}
+          private_key: ${{ secrets.KEYCHAIN_BOT_PRIVATE_KEY }}
+
+      - uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
+        with:
+          token: ${{ steps.app_token.outputs.token }}
+          commit-message: 'bump(deps): `expo install --fix`'
+          title: 'bump(deps): `expo install --fix`'
+          committer: Keychain Bot <githubapp+349640@users.noreply.github.com>
+          author: Keychain Bot <githubapp+349640@users.noreply.github.com>
+          body: |
+            #### What this PR does / why we need it:
+
+            Bump expo dependencies to newest release with `expo install --fix`, this command also fixes `./app/package.json` and `./app/app.json` files to patch any non-compliant dependencies.
+          branch: keychain-bot/expo-install-fixes


### PR DESCRIPTION
#### What this PR does / why we need it:

As per title to automate dependencies fix.