### PR TITLE
chore(app): change playwright dir to `.playwright`

### DIFF
--- a/.idea/keychain.iml
+++ b/.idea/keychain.iml
@@ -6,8 +6,8 @@
       <excludeFolder url="file://$MODULE_DIR$/app/.expo" />
       <excludeFolder url="file://$MODULE_DIR$/app/.turbo" />
       <excludeFolder url="file://$MODULE_DIR$/app/dist" />
-      <excludeFolder url="file://$MODULE_DIR$/app/playwright" />
       <excludeFolder url="file://$MODULE_DIR$/app/tailwind.json" />
+      <excludeFolder url="file://$MODULE_DIR$/app/.playwright" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,5 +8,6 @@ yarn.lock
 .contented
 .expo
 .turbo
-app/playwright
+.playwright
+app/dist
 app/tailwind.json

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,2 @@
 tailwind.json
-playwright/
+.playwright

--- a/app/playwright.config.js
+++ b/app/playwright.config.js
@@ -27,13 +27,13 @@ export default defineConfig({
   // Opt out of parallel tests on CI.
   workers: process.env.CI ? 1 : undefined,
 
-  outputDir: './playwright/test-results',
+  outputDir: './.playwright/test-results',
 
   // Reporter to use
   reporter: [
     // For GitHub Actions CI to generate annotations
     ['github'],
-    ['html', { outputFolder: './playwright/test-report' }],
+    ['html', { outputFolder: './.playwright/test-report' }],
   ],
 
   use: {


### PR DESCRIPTION
#### What this PR does / why we need it:

As per the title, use `.playwright` directory to indicate that this is non src directory.